### PR TITLE
update mysql version to 8

### DIFF
--- a/06-run-simple-application-in-kubernetes/README.md
+++ b/06-run-simple-application-in-kubernetes/README.md
@@ -36,7 +36,7 @@ Notice: `StatefulSet` is more preferable resource to manage database application
     Create base yaml file:
 
     ```
-    kubectl create deploy mysql --image=mysql:5.7 --dry-run=client -o yaml > mysql-deployment.yaml
+    kubectl create deploy mysql --image=mysql:8 --dry-run=client -o yaml > mysql-deployment.yaml
     ```
 
     Add required `env`:
@@ -92,10 +92,10 @@ Notice: `StatefulSet` is more preferable resource to manage database application
         ```sql
         mysql: [Warning] Using a password on the command line interface can be insecure.
         Welcome to the MySQL monitor.  Commands end with ; or \g.
-        Your MySQL connection id is 3
-        Server version: 5.7.35 MySQL Community Server (GPL)
+        Your MySQL connection id is 8
+        Server version: 8.0.31 MySQL Community Server - GPL
 
-        Copyright (c) 2000, 2021, Oracle and/or its affiliates.
+        Copyright (c) 2000, 2022, Oracle and/or its affiliates.
 
         Oracle is a registered trademark of Oracle Corporation and/or its
         affiliates. Other names may be trademarks of their respective

--- a/06-run-simple-application-in-kubernetes/mysql-deployment.yaml
+++ b/06-run-simple-application-in-kubernetes/mysql-deployment.yaml
@@ -18,8 +18,12 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.7
-        name: mysql
+      - name: mysql
+        image: mysql:8
+        args:
+         - --default-authentication-plugin=mysql_native_password
+        # caching_sha2_password is used for the default auth from mysql:8
+        # which requires more dependencies in client side.
         # https://hub.docker.com/_/mysql
         env:
           - name: MYSQL_ROOT_PASSWORD

--- a/09-cicd/mysql-manifests/deployment.yaml
+++ b/09-cicd/mysql-manifests/deployment.yaml
@@ -18,7 +18,7 @@ spec:
         app: mysql
     spec:
       containers:
-      - image: mysql:5.7
+      - image: mysql:8
         name: mysql
         # https://hub.docker.com/_/mysql
         env:


### PR DESCRIPTION
Failure on M1 Mac

```
kubectl get pod
NAME                     READY   STATUS         RESTARTS   AGE
mysql-5d8dcd4f7b-qjnjb   0/1     ErrImagePull   0          15s
```

```
docker pull mysql:5.7
5.7: Pulling from library/mysql
no matching manifest for linux/arm64/v8 in the manifest list entries
```

