### PR TITLE
chore: specify mysql:8.3

### DIFF
--- a/06-run-simple-application-in-kubernetes/mysql-deployment.yaml
+++ b/06-run-simple-application-in-kubernetes/mysql-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: mysql
-        image: mysql:8
+        image: mysql:8.3
         args:
          - --default-authentication-plugin=mysql_native_password
         # caching_sha2_password is used for the default auth from mysql:8


### PR DESCRIPTION
# why

`--default-authentication-plugin=mysql_native_password` is disabled in 8.4

> Important Change: The deprecated mysql_native_password authentication plugin is now disabled by default. It can be enabled by starting MySQL with the new [--mysql-native-password=ON](https://dev.mysql.com/doc/refman/8.4/en/server-options.html#option_mysqld_mysql-native-password) server option, or by adding mysql_native_password=ON to the [mysqld] section of your MySQL configuration file.

To make the code work

# what

specify mysql:8.3

# ref

- https://dev.mysql.com/doc/relnotes/mysql/8.4/en/news-8-4-0.html